### PR TITLE
prepare .irodsA before server start

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,10 +90,10 @@ RUN python2 get-pip.py
 RUN pip install requests
 
 # Copy scripts and templates
-COPY docker-entrypoint.sh files/irods_login.sh \
+COPY docker-entrypoint.sh \
      templates/core.py.j2 templates/unattended_config.json.j2 \
      templates/irods.pam.j2 files/j2-filters.py templates/pam_sodar.py.j2 /
-RUN chmod +x /docker-entrypoint.sh /irods_login.sh
+RUN chmod +x /docker-entrypoint.sh
 
 # Set up logging
 COPY files/irods_syslog.conf /etc/rsyslog.d/00-irods.conf

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -84,6 +84,12 @@ if [[ "$1" == "irods-start" ]]; then
 
     find /var/lib/irods -not -path '/var/lib/irods/Vault*' -exec chown $IRODS_SERVICE_ACCOUNT_GROUP:$IRODS_SERVICE_ACCOUNT_USER {} \;
 
+    # Generate .irodsA
+    echo "Prepare service account"
+    set +e
+    su - irods -c "echo ${IRODS_ADMIN_PASS} | iinit > /dev/null 2>&1"
+    set -e
+
     # Start iRODS
     echo "Start iRODS"
     /etc/init.d/irods start
@@ -96,15 +102,12 @@ if [[ "$1" == "irods-start" ]]; then
     done
     sleep 5
 
-    echo "Test iinit"
-    su - irods -c "/irods_login.sh ${IRODS_ADMIN_PASS}"
-    echo "iCAT at ${IRODS_HOST_NAME} ready!"
-
     # Set minimum session timeout
     if [[ "$IRODS_ROLE" == "provider" ]]; then
         su - irods -c "iadmin set_grid_configuration authentication password_min_time ${IRODS_PASSWORD_MIN_TIME}"
     fi
 
+    echo "iRODS is ready"
     sleep infinity
 
 fi

--- a/docker/files/irods_login.sh
+++ b/docker/files/irods_login.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-echo $1 | iinit
-
-if [ $? -ne 0 ]; then
-    echo "iinit failed"
-fi


### PR DESCRIPTION
Since we already have the `${IRODS_ADMIN_PASS}` - we might as well just recreate the `.irodsA` on each container startup.

When the server didn't have a good `.irodsA` at startup... the delay server couldn't begin (one of the first things the server does on startup is connect to itself as a client and issue a command)..  and this was failing since the environment was missing a `.irodsA` file.

`iinit` will fail to connect to the server before it is up (therefore, `set +e` and `set -e`) - but it will write down the new `.irodsA` file regardless.

Also - removed `files/irods_login.sh` as it didn't seem to be used elsewhere.  Please restore it if that is not correct.